### PR TITLE
Updated code to check sha512sum and download content

### DIFF
--- a/modules/infrastructure/aws/main.tf
+++ b/modules/infrastructure/aws/main.tf
@@ -1,17 +1,17 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  private_ssh_key_path = var.ssh_private_key_path == null ? "${path.cwd}/${var.prefix}-ssh_private_key.pem" : var.ssh_private_key_path
-  public_ssh_key_path  = var.ssh_public_key_path == null ? "${path.cwd}/${var.prefix}-ssh_public_key.pem" : var.ssh_public_key_path
-  target_vpc_id        = var.use_existing_vpc ? var.vpc_id : aws_vpc.default_vpc[0].id
-  target_subnet_id     = var.use_existing_vpc ? var.subnet_id : aws_subnet.default_subnet[0].id
-  host                 = var.associate_public_ip ? aws_instance.opensuse_gpu[0].public_ip : aws_instance.opensuse_gpu[0].private_ip
-  instance_count       = 1
-  ssh_username         = var.certified_os_image ? "opensuse" : "ec2-user"
-  certified_image_name = "opensuse-leap-15-6-suse-ai-tf-cloud-image.x86_64.vhd"
-  certified_image_url  = var.certified_os_image ? "https://github.com/devenkulkarni/suse-ai-tf/releases/download/${var.certified_os_image_tag}/${local.certified_image_name}" : null
-
-  username = element(split("/", data.aws_caller_identity.current.arn), length(split("/", data.aws_caller_identity.current.arn)) - 1)
+  private_ssh_key_path   = var.ssh_private_key_path == null ? "${path.cwd}/${var.prefix}-ssh_private_key.pem" : var.ssh_private_key_path
+  public_ssh_key_path    = var.ssh_public_key_path == null ? "${path.cwd}/${var.prefix}-ssh_public_key.pem" : var.ssh_public_key_path
+  target_vpc_id          = var.use_existing_vpc ? var.vpc_id : aws_vpc.default_vpc[0].id
+  target_subnet_id       = var.use_existing_vpc ? var.subnet_id : aws_subnet.default_subnet[0].id
+  host                   = var.associate_public_ip ? aws_instance.opensuse_gpu[0].public_ip : aws_instance.opensuse_gpu[0].private_ip
+  instance_count         = 1
+  ssh_username           = var.certified_os_image ? "opensuse" : "ec2-user"
+  certified_image_name   = "opensuse-leap-15-6-suse-ai-tf-cloud-image.x86_64.vhd"
+  certified_image_url    = var.certified_os_image ? "https://github.com/devenkulkarni/suse-ai-tf/releases/download/${var.certified_os_image_tag}/${local.certified_image_name}" : null
+  certified_image_sha512 = "5cdf863e0548498585e951e861adee67054fb7f762161cdbf6e469b9a63564aa256a53cb9f8009cac9aaf6c7467de938a9c2a3d3ea2c756aa99f295b487defc5"
+  username               = element(split("/", data.aws_caller_identity.current.arn), length(split("/", data.aws_caller_identity.current.arn)) - 1)
   common_tags = {
     Owner = local.username
   }
@@ -70,15 +70,39 @@ resource "local_file" "private_key_pem" {
 
 resource "null_resource" "download_certified_vhd" {
   count = var.certified_os_image ? 1 : 0
+
   provisioner "local-exec" {
     command = <<-EOT
-      set -e
-      if [ ! -f "${path.cwd}/${local.certified_image_name}" ]; then
-        echo "Downloading certified VHD..."
-        curl -L -o "${path.cwd}/${local.certified_image_name}" "${local.certified_image_url}"
-      else
-        echo "Certified VHD already exists, skipping download"
+      set -euo pipefail
+
+      FILE="${path.cwd}/${local.certified_image_name}"
+      EXPECTED="${local.certified_image_sha512}"
+
+      if [ -f "$FILE" ]; then
+        echo "File exists. Verifying checksum..."
+
+        if echo "$EXPECTED  $FILE" | sha512sum -c - >/dev/null 2>&1; then
+          echo "Checksum valid. Skipping download."
+          exit 0
+        else
+          echo "Checksum mismatch. Re-downloading..."
+          rm -f "$FILE"
+        fi
       fi
+
+      echo "Downloading + hashing in one pass..."
+
+      ACTUAL=$(curl -L --fail --retry 5 --retry-delay 5 "${local.certified_image_url}" \
+        | tee "$FILE" \
+        | sha512sum | awk '{print $1}')
+
+      if [ "$ACTUAL" != "$EXPECTED" ]; then
+        echo "ERROR: Checksum mismatch!"
+        rm -f "$FILE"
+        exit 1
+      fi
+
+      echo "Download + checksum verification successful."
     EOT
   }
 }

--- a/modules/infrastructure/azure/main.tf
+++ b/modules/infrastructure/azure/main.tf
@@ -9,6 +9,7 @@ locals {
   os_image_version     = "latest"
   certified_image_name = "opensuse-leap-15-6-suse-ai-tf-cloud-image.x86_64.vhd"
   certified_image_url  = var.certified_os_image ? "https://github.com/devenkulkarni/suse-ai-tf/releases/download/${var.certified_os_image_tag}/${local.certified_image_name}" : null
+  certified_image_sha512 = "5cdf863e0548498585e951e861adee67054fb7f762161cdbf6e469b9a63564aa256a53cb9f8009cac9aaf6c7467de938a9c2a3d3ea2c756aa99f295b487defc5"
   ssh_username         = var.certified_os_image ? "opensuse" : "azureuser"
 }
 
@@ -49,15 +50,39 @@ resource "azurerm_storage_container" "vhds" {
 
 resource "null_resource" "download_certified_vhd" {
   count = var.certified_os_image ? 1 : 0
+
   provisioner "local-exec" {
     command = <<-EOT
-      set -e
-      if [ ! -f "${path.cwd}/${local.certified_image_name}" ]; then
-        echo "Downloading certified VHD..."
-        curl -L -o "${path.cwd}/${local.certified_image_name}" "${local.certified_image_url}"
-      else
-        echo "Certified VHD already exists, skipping download"
+      set -euo pipefail
+
+      FILE="${path.cwd}/${local.certified_image_name}"
+      EXPECTED="${local.certified_image_sha512}"
+
+      if [ -f "$FILE" ]; then
+        echo "File exists. Verifying checksum..."
+
+        if echo "$EXPECTED  $FILE" | sha512sum -c - >/dev/null 2>&1; then
+          echo "Checksum valid. Skipping download."
+          exit 0
+        else
+          echo "Checksum mismatch. Re-downloading..."
+          rm -f "$FILE"
+        fi
       fi
+
+      echo "Downloading + hashing in one pass..."
+
+      ACTUAL=$(curl -L --fail --retry 5 --retry-delay 5 "${local.certified_image_url}" \
+        | tee "$FILE" \
+        | sha512sum | awk '{print $1}')
+
+      if [ "$ACTUAL" != "$EXPECTED" ]; then
+        echo "ERROR: Checksum mismatch!"
+        rm -f "$FILE"
+        exit 1
+      fi
+
+      echo "Download + checksum verification successful."
     EOT
   }
 }

--- a/modules/infrastructure/gcp/main.tf
+++ b/modules/infrastructure/gcp/main.tf
@@ -8,6 +8,7 @@ locals {
   ssh_username         = var.ssh_username
   certified_image_name = "opensuse-leap-15-6-suse-ai-tf-cloud-image.x86_64.raw.tar.gz"
   certified_image_url  = var.certified_os_image ? "https://github.com/devenkulkarni/suse-ai-tf/releases/download/${var.certified_os_image_tag}/${local.certified_image_name}" : null
+  certified_image_sha512 = "6b43e8152f37f5697b052cb27377af40348ea1c28d6f764afea0147b23f329a6b790c4744216632a368362630adb34e4039ae67be2b13a92d30e53e43c5241ca" 
 }
 
 resource "tls_private_key" "ssh_private_key" {
@@ -40,15 +41,39 @@ data "google_compute_image" "os_image" {
 
 resource "null_resource" "download_image" {
   count = var.certified_os_image ? 1 : 0
+
   provisioner "local-exec" {
     command = <<-EOT
-      set -e
-      if [ ! -f "${path.cwd}/${local.certified_image_name}" ]; then
-        echo "Downloading certified VHD..."
-        curl -L -o "${path.cwd}/${local.certified_image_name}" "${local.certified_image_url}"
-      else
-        echo "Certified VHD already exists, skipping download"
+      set -euo pipefail
+
+      FILE="${path.cwd}/${local.certified_image_name}"
+      EXPECTED="${local.certified_image_sha512}"
+
+      if [ -f "$FILE" ]; then
+        echo "File exists. Verifying checksum..."
+
+        if echo "$EXPECTED  $FILE" | sha512sum -c - >/dev/null 2>&1; then
+          echo "Checksum valid. Skipping download."
+          exit 0
+        else
+          echo "Checksum mismatch. Re-downloading..."
+          rm -f "$FILE"
+        fi
       fi
+
+      echo "Downloading + hashing in one pass..."
+
+      ACTUAL=$(curl -L --fail --retry 5 --retry-delay 5 "${local.certified_image_url}" \
+        | tee "$FILE" \
+        | sha512sum | awk '{print $1}')
+
+      if [ "$ACTUAL" != "$EXPECTED" ]; then
+        echo "ERROR: Checksum mismatch!"
+        rm -f "$FILE"
+        exit 1
+      fi
+
+      echo "Download + checksum verification successful."
     EOT
   }
 }

--- a/modules/infrastructure/scripts/rke2-localpath-install.sh
+++ b/modules/infrastructure/scripts/rke2-localpath-install.sh
@@ -5,6 +5,10 @@ set -e
 K8S_BIN="/var/lib/rancher/rke2/bin/kubectl"
 K8S_CONFIG="/etc/rancher/rke2/rke2.yaml"
 
+# Define Trusted Checksums:
+RKE2_INSTALL_SHA="49b21b3edd6f2ba87e732aeb6a709668302806efb55a060f64db9f680c97dfe096ecc9ec4f95ecaa30af46042c288c115c1d54b9566e4313b993e147b8c442d4"
+LOCAL_PATH_SHA="b7ad6b277a3fa2950fe86ecaf475db7bc5276b284a9fe662f56b10d182304f9e939ca92a823943560275586474c09d42cb6dfaeb51de3273ca7004c90127eaf8"
+
 echo "Starting RKE2 installation..."
 
 # 1. Create RKE2 directories
@@ -21,7 +25,10 @@ ingress-controller: traefik
 EOF
 
 # 3. Install RKE2
-curl -sfL https://get.rke2.io | sudo INSTALL_RKE2_VERSION=${rke2_version} sh -
+echo "Downloading and verifying RKE2 installer..."
+curl -sfL -o install_rke2.sh https://get.rke2.io
+echo "$RKE2_INSTALL_SHA  install_rke2.sh" | sha512sum -c -
+sudo INSTALL_RKE2_VERSION=${rke2_version} sh install_rke2.sh
 
 # 4. Enable and Start Service
 sudo systemctl enable --now rke2-server
@@ -60,7 +67,12 @@ done
 
 # 6. Apply Local Path Provisioner
 echo "Applying Local Path Provisioner..."
+echo "Downloading and verifying Local Path Provisioner manifest..."
+LOCAL_PATH_URL="https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.31/deploy/local-path-storage.yaml"
+curl -sfL -o local-path-storage.yaml "$LOCAL_PATH_URL"
+echo "$LOCAL_PATH_SHA  local-path-storage.yaml" | sha512sum -c -
+
 # We use the absolute path to kubectl and point to the config explicitly
-sudo $K8S_BIN --kubeconfig $K8S_CONFIG apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.31/deploy/local-path-storage.yaml
+sudo $K8S_BIN --kubeconfig $K8S_CONFIG apply -f local-path-storage.yaml
 
 echo "RKE2 installation with localpath storage provisioner completed successfully."


### PR DESCRIPTION
- Updated infrastructure/scripts/rke2-localpath-install.sh to check sha512sum before downloading content.
- Updated infrastructure/{aws,gcp,azure} to download certified image and verify checksum after download because checking the checksum before downloading was causing a lot of time delay cz the large size image was streamed first into memory causing a lot of time delay.