### PR TITLE
fix: normalize all outputs.tf files for consistency across modules and d public-clouds

### DIFF
--- a/modules/infrastructure/aws/outputs.tf
+++ b/modules/infrastructure/aws/outputs.tf
@@ -1,22 +1,25 @@
 output "instance_public_ip" {
-  value = aws_instance.opensuse_gpu[0].public_ip
+  description = "The public IP address of the VM"
+  value       = aws_instance.opensuse_gpu[0].public_ip
 }
 
 output "kubeconfig_path" {
-  value = "${path.cwd}/kubeconfig-rke2.yaml"
+  description = "Local path to the generated kubeconfig file"
+  value       = "${path.cwd}/kubeconfig-rke2.yaml"
 }
 
 output "ssh_command" {
-  description = "Convenience command to login"
+  description = "Convenience command to SSH into the VM"
   value       = "ssh -i ${local.private_ssh_key_path} ${local.ssh_username}@${aws_instance.opensuse_gpu[0].public_ip}"
 }
 
 output "kubeconfig_done" {
-  value = null_resource.retrieve_kubeconfig.id
+  description = "ID of the kubeconfig retrieval resource, used to track completion"
+  value       = null_resource.retrieve_kubeconfig.id
 }
 
 output "ssh_private_key_content" {
-  description = "The content of the generated private key"
+  description = "The content of the generated private SSH key"
   value       = var.create_ssh_key_pair ? tls_private_key.ssh_private_key[0].private_key_openssh : file(local.private_ssh_key_path)
   sensitive   = true
 }

--- a/modules/infrastructure/azure/outputs.tf
+++ b/modules/infrastructure/azure/outputs.tf
@@ -1,26 +1,26 @@
 output "instance_public_ip" {
-  description = "The public IP address of the Azure VM"
+  description = "The public IP address of the VM"
   # In Azure, we reference the Public IP resource directly
   value = azurerm_public_ip.pip[0].ip_address
 }
 
 output "kubeconfig_path" {
-  description = "Path to the generated Kubeconfig file"
+  description = "Local path to the generated kubeconfig file"
   value       = "${path.cwd}/kubeconfig-rke2.yaml"
 }
 
 output "ssh_command" {
-  description = "Convenience command to login via SSH"
+  description = "Convenience command to SSH into the VM"
   value       = "ssh -i ${local.private_ssh_key_path} ${local.ssh_username}@${azurerm_public_ip.pip[0].ip_address}"
 }
 
 output "kubeconfig_done" {
-  description = "ID of the Kubeconfig retrieval resource to track completion"
+  description = "ID of the kubeconfig retrieval resource, used to track completion"
   value       = null_resource.retrieve_kubeconfig.id
 }
 
 output "ssh_private_key_content" {
-  description = "The content of the generated private key"
+  description = "The content of the generated private SSH key"
   value       = var.create_ssh_key_pair ? tls_private_key.ssh_private_key[0].private_key_openssh : file(local.private_ssh_key_path)
   sensitive   = true
 }

--- a/modules/infrastructure/gcp/outputs.tf
+++ b/modules/infrastructure/gcp/outputs.tf
@@ -1,24 +1,26 @@
 output "instance_public_ip" {
-  description = "The public IP of the GPU instance"
+  description = "The public IP address of the VM"
   value       = google_compute_instance.default[0].network_interface[0].access_config[0].nat_ip
 }
 
+output "kubeconfig_path" {
+  description = "Local path to the generated kubeconfig file"
+  value       = "${path.cwd}/kubeconfig-rke2.yaml"
+}
+
 output "ssh_command" {
-  description = "Convenience command to login"
+  description = "Convenience command to SSH into the VM"
   value       = "ssh -i ${local.private_ssh_key_path} ${local.ssh_username}@${google_compute_instance.default[0].network_interface[0].access_config[0].nat_ip}"
 }
 
-output "kubeconfig_path" {
-  value = "${path.cwd}/kubeconfig-rke2.yaml"
+output "kubeconfig_done" {
+  description = "ID of the kubeconfig retrieval resource, used to track completion"
+  value       = null_resource.retrieve_kubeconfig.id
 }
 
 output "ssh_private_key_content" {
-  description = "The content of the generated private key"
+  description = "The content of the generated private SSH key"
   value       = var.create_ssh_key_pair ? tls_private_key.ssh_private_key[0].private_key_openssh : file(local.private_ssh_key_path)
   sensitive   = true
-}
-
-output "kubeconfig_done" {
-  value = null_resource.retrieve_kubeconfig.id
 }
 

--- a/public-clouds/aws/outputs.tf
+++ b/public-clouds/aws/outputs.tf
@@ -1,5 +1,5 @@
 output "suse_ai_webui_url" {
-  description = "URL for accessing the SUSE AI webUI"
+  description = "URL for accessing the SUSE AI Web UI"
   value       = "suse-ai.${module.infrastructure.instance_public_ip}.sslip.io"
 }
 
@@ -9,11 +9,11 @@ output "instance_public_ip" {
 }
 
 output "kubeconfig_path" {
-  description = "The local path to the generated kubeconfig file"
+  description = "Local path to the generated kubeconfig file"
   value       = "${path.cwd}/kubeconfig-rke2.yaml"
 }
 
 output "ssh_command" {
-  description = "Command to connect to the VM"
-  value       = "ssh -i ${local.private_ssh_key_path} ${var.ssh_username}@${module.infrastructure.instance_public_ip}"
+  description = "Convenience command to SSH into the VM"
+  value       = "ssh -i ${local.private_ssh_key_path} ${local.ssh_username}@${module.infrastructure.instance_public_ip}"
 }

--- a/public-clouds/azure/outputs.tf
+++ b/public-clouds/azure/outputs.tf
@@ -1,5 +1,5 @@
 output "suse_ai_webui_url" {
-  description = "URL for accessing the SUSE AI webUI"
+  description = "URL for accessing the SUSE AI Web UI"
   value       = "suse-ai.${module.infrastructure.instance_public_ip}.sslip.io"
 }
 
@@ -9,11 +9,11 @@ output "instance_public_ip" {
 }
 
 output "kubeconfig_path" {
-  description = "The local path to the generated kubeconfig file"
+  description = "Local path to the generated kubeconfig file"
   value       = "${path.cwd}/kubeconfig-rke2.yaml"
 }
 
 output "ssh_command" {
-  description = "Command to connect to the VM"
-  value       = "ssh -i ${local.private_ssh_key_path} ${var.ssh_username}@${module.infrastructure.instance_public_ip}"
+  description = "Convenience command to SSH into the VM"
+  value       = "ssh -i ${local.private_ssh_key_path} ${local.ssh_username}@${module.infrastructure.instance_public_ip}"
 }

--- a/public-clouds/gcp/outputs.tf
+++ b/public-clouds/gcp/outputs.tf
@@ -1,18 +1,19 @@
+output "suse_ai_webui_url" {
+  description = "URL for accessing the SUSE AI Web UI"
+  value       = "suse-ai.${module.infrastructure.instance_public_ip}.sslip.io"
+}
+
 output "instance_public_ip" {
-  description = "The public IP of the GPU instance"
+  description = "The public IP of the openSUSE VM"
   value       = module.infrastructure.instance_public_ip
 }
 
-output "ssh_command" {
-  description = "Convenience command to login"
-  value       = "ssh -i ${local.private_ssh_key_path} ${local.ssh_username}@${module.infrastructure.instance_public_ip}"
-}
-
 output "kubeconfig_path" {
-  value = "${path.cwd}/kubeconfig-rke2.yaml"
+  description = "Local path to the generated kubeconfig file"
+  value       = "${path.cwd}/kubeconfig-rke2.yaml"
 }
 
-output "suse_ai_webui_url" {
-  description = "URL for accessing the SUSE AI webUI"
-  value       = "suse-ai.${module.infrastructure.instance_public_ip}.sslip.io"
+output "ssh_command" {
+  description = "Convenience command to SSH into the VM"
+  value       = "ssh -i ${local.private_ssh_key_path} ${local.ssh_username}@${module.infrastructure.instance_public_ip}"
 }


### PR DESCRIPTION

- Rename public-clouds/aws/output.tf to outputs.tf for consistent naming
- Add missing descriptions to all output blocks
- Align description wording across aws/azure/gcp in both layers
- Fix output ordering in gcp files to match aws/azure canonical order
- Fix var.ssh_username -> local.ssh_username in public-clouds/aws and azure
- Fixes #137