### PR TITLE
fix: correct GCP rke2_version default and ha_setup variable issues

### DIFF
--- a/public-clouds/gcp/terraform.tfvars.example
+++ b/public-clouds/gcp/terraform.tfvars.example
@@ -62,4 +62,4 @@ rancher_insecure = false
 public_ip_source_addresses = []
 
 ## Set to true for 3-node HA cluste
-ha-setup = false
+ha_setup = false

--- a/public-clouds/gcp/variables.tf
+++ b/public-clouds/gcp/variables.tf
@@ -163,7 +163,7 @@ variable "zone" {
 variable "rke2_version" {
   description = "The version of RKE2 to install"
   type        = string
-  default     = "null"
+  default     = "v1.32.10+rke2r1" 
 }
 
 variable "registry_name" {
@@ -250,7 +250,7 @@ variable "public_ip_source_addresses" {
 }
 
 variable "ha_setup" {
-  description = "Set to true for 3-node HA cluster"
+  description = "Set to true to deploy a 3-node HA RKE2 cluster with Longhorn. Default is single-node"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
- Fix rke2_version default from literal string null to v1.32.10+rke2r1
- Fix ha-setup typo to ha_setup in gcp terraform.tfvars.example
- Improve ha_setup description to explain what changes in HA mode